### PR TITLE
Adds ability to specify KeyId to SSH Cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module go.cfdata.org/ztia/sshcert
+
+go 1.21.13
+
+require (
+	github.com/spf13/cobra v1.8.1
+	golang.org/x/crypto v0.28.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
+golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
+golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sshcert.go
+++ b/sshcert.go
@@ -64,11 +64,13 @@ type Cert struct {
 // If you would like to read more about how to configure the SigningArguments
 // then I found the following to be a good source of information:
 //   - https://github.com/metacloud/openssh/blob/master/PROTOCOL.certkeys
+//
 // If you would like to use default settings then call `NewSigningArguments`
 type SigningArguments struct {
 	Principals  []string
 	Permissions ssh.Permissions
 	Duration    time.Duration
+	KeyId       string // "the contents of [KeyId] are used to identify the identity principal in log messages"
 }
 
 // NewCA will instantiate a new CA and generate a fresh ecdsa Private key.
@@ -83,11 +85,15 @@ func NewCA() (CA, error) {
 // SignCert is called to sign an ssh public key and produce an ssh certificate.
 // It's required to pass in SigningArguments or the signing will fail.
 func (c *CA) SignCert(pub ssh.PublicKey, signArgs *SigningArguments) (*Cert, error) {
+	if signArgs.KeyId == "" {
+		signArgs.KeyId = randomHex()
+	}
+
 	cert := &ssh.Certificate{
 		Key:      pub,
 		Serial:   randomSerial(),
 		CertType: ssh.UserCert,
-		KeyId:    randomHex(),
+		KeyId:    signArgs.KeyId,
 		// Subtract 60 seconds to allow for some clock drift between the signature signing and the remote servers
 		ValidAfter:      uint64(time.Now().Add(-allowableDrift).Unix()),
 		ValidBefore:     uint64(time.Now().Add(signArgs.Duration).Unix()),
@@ -193,9 +199,14 @@ func (s *SigningArguments) SetDuration(d time.Duration) {
 	s.Duration = d
 }
 
-// // SetPrincipals will set the principals of a SigningArguments type.
+// SetPrincipals will set the principals of a SigningArguments type.
 func (s *SigningArguments) SetPrincipals(principals []string) {
 	s.Principals = principals
+}
+
+// SetKeyId will set the KeyId of a SigningArguments type.
+func (s *SigningArguments) SetKeyId(keyId string) {
+	s.KeyId = keyId
 }
 
 // ParsePublicKey will parse and return an SSH public key from it's
@@ -206,6 +217,9 @@ func ParsePublicKey(pub string) (ssh.PublicKey, error) {
 		return nil, errors.New("Invalid public key format")
 	}
 	pubBytes, err := base64.StdEncoding.DecodeString(pubParts[1])
+	if err != nil {
+		return nil, err
+	}
 	pubKey, err := ssh.ParsePublicKey(pubBytes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Prior to this PR the key id of the SSH certificate was always chosen to be a random value. This PR changes this so that the key ID (a.k.a. the Certificate ID) can be specified by the user in the SigningArguments passed SignCert. This PR maintains backwards compatibility, if no key ID is specified to defaults to the old behavior.

By allowing the key ID to specified in the Signing Argument, the key ID can be associated with the user's identity as intended to OpenSSH.

"key id is a free-form text field that is filled in by the CA at the time of signing; the intention is that the contents of this field are used to identify the identity principal in log messages." -[OpenSSH Certificate Spec](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD)

This PR:
- Updates SigningArguments struct to take key id. The key id is then included in the signed certificate
- A unit test tests to verify this new behavior, checks that backwards compatibility is maintained and improves coverage on the other fields of the SigningArguments
- Fixes minor bug where we didn't catch an error if base64 decoding failed.
- Updates the go version to 1.22.4 and adds a go.mod file. Before this PR the go version was old enough that it didn't have a go.mod file.